### PR TITLE
Get bitswap test against go-ipfs working

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aes-soft 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ctr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctr 0.3.2 (git+https://github.com/koivunej/stream-ciphers.git?branch=ctr128-64to128)",
  "stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "ctr"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/stream-ciphers.git?branch=ctr128-64to128#3c5a767bd30d17998515df29c93bd50b6486cc66"
 dependencies = [
  "block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1225,7 +1225,7 @@ source = "git+https://github.com/libp2p/rust-libp2p#88c2287e444d9c6bb25bf84a30fc
 dependencies = [
  "aes-ctr 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "ctr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctr 0.3.2 (git+https://github.com/koivunej/stream-ciphers.git?branch=ctr128-64to128)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2786,7 +2786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-"checksum ctr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
+"checksum ctr 0.3.2 (git+https://github.com/koivunej/stream-ciphers.git?branch=ctr128-64to128)" = "<none>"
 "checksum cuckoofilter 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd43f7cfaffe0a386636a10baea2ee05cc50df3b77bea4a456c9572a939bf1f"
 "checksum curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
 "checksum data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ xdg = "*"
 async-trait = "*"
 
 rocksdb = { version = "*", optional = true }
+
+[patch.crates-io]
+ctr = { git = "https://github.com/koivunej/stream-ciphers.git", branch = "ctr128-64to128" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use libp2p::{Multiaddr, PeerId};
 use libp2p::multiaddr::Protocol;
-use libp2p::identity::Keypair;
+use libp2p::identity::{Keypair, PublicKey};
 use rand::{Rng, rngs::EntropyRng};
 use serde_derive::{Serialize, Deserialize};
 use std::fs;
@@ -18,39 +18,139 @@ const BOOTSTRAP_NODES: &[&'static str] = &[
     "/ip6/2a03:b0c0:0:1010::23:1001/tcp/4001/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
 ];
 
+/// See test cases for examples how to write such file.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConfigFile {
-    private_key: [u8; 32],
+    #[serde(flatten)]
+    key: KeyMaterial,
     bootstrap: Vec<Multiaddr>,
+}
+
+/// KeyMaterial is an additional abstraction as the identity::Keypair does not support Clone or
+/// Debug nor is there a clearcut way to serialize and deserialize such yet at least.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum KeyMaterial {
+    Ed25519 {
+        private_key: [u8; 32],
+        #[serde(skip)]
+        keypair: Option<libp2p::identity::ed25519::Keypair>,
+    },
+    RsaPkcs8File {
+        #[serde(rename = "rsa_pkcs8_filename")]
+        filename: String,
+        #[serde(skip)]
+        keypair: Option<libp2p::identity::rsa::Keypair>,
+    },
+}
+
+use std::fmt;
+
+impl fmt::Debug for KeyMaterial {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            KeyMaterial::Ed25519 { ref keypair, .. } =>
+                if let Some(kp) = keypair.as_ref() {
+                    write!(fmt, "{:?}", kp)
+                } else {
+                    write!(fmt, "Ed25519(not loaded)")
+                },
+            KeyMaterial::RsaPkcs8File { ref keypair, ref filename } =>
+                if let Some(kp) = keypair.as_ref() {
+                    write!(fmt, "{:?}", kp.public())
+                } else {
+                    write!(fmt, "Rsa(not loaded: {:?})", filename)
+                },
+        }
+    }
+}
+
+#[derive(Debug)]
+enum KeyMaterialLoadingFailure {
+    Io(std::io::Error),
+    RsaDecoding(libp2p::identity::error::DecodingError),
+}
+
+impl KeyMaterial {
+
+    fn clone_keypair(&self) -> Keypair {
+        match *self {
+            KeyMaterial::Ed25519 { ref keypair, .. } => keypair.clone().map(Keypair::Ed25519),
+            KeyMaterial::RsaPkcs8File { ref keypair, .. } => keypair.clone().map(Keypair::Rsa),
+        }.expect("KeyMaterial needs to be loaded before accessing the keypair")
+    }
+
+    fn public(&self) -> PublicKey {
+        self.clone_keypair().public()
+    }
+
+    fn load(&mut self) -> Result<(), KeyMaterialLoadingFailure> {
+        match self {
+            &mut KeyMaterial::Ed25519 { ref private_key, ref mut keypair } if keypair.is_none() => {
+                let mut cloned = private_key.clone();
+                let sk = libp2p::identity::ed25519::SecretKey::from_bytes(&mut cloned)
+                    .expect("Failed to extract ed25519::SecretKey");
+
+                let kp = libp2p::identity::ed25519::Keypair::from(sk);
+
+                *keypair = Some(kp);
+            },
+            &mut KeyMaterial::RsaPkcs8File { ref filename, ref mut keypair } if keypair.is_none() => {
+                let mut bytes = std::fs::read(filename)
+                    .map_err(|e| KeyMaterialLoadingFailure::Io(e))?;
+                let kp = libp2p::identity::rsa::Keypair::from_pkcs8(&mut bytes)
+                    .map_err(|e| KeyMaterialLoadingFailure::RsaDecoding(e))?;
+                *keypair = Some(kp);
+            }
+            _ => { /* all set */ }
+        }
+
+        Ok(())
+    }
+
+    fn into_loaded(mut self) -> Result<Self, KeyMaterialLoadingFailure> {
+        self.load()?;
+        Ok(self)
+    }
 }
 
 impl ConfigFile {
     pub fn new<P: AsRef<Path>>(path: P) -> Self {
-        fs::read_to_string(&path).map(|content| {
-            serde_json::from_str(&content).unwrap()
-        }).unwrap_or_else(|_| {
-            let config = ConfigFile::default();
-            let string = serde_json::to_string_pretty(&config).unwrap();
-            fs::write(path, string).unwrap();
-            config
-        })
+        fs::read_to_string(&path)
+            .map(|content| Self::parse(&content))
+            .map(|parsed| parsed.into_loaded().unwrap())
+            .unwrap_or_else(|_| {
+                let config = ConfigFile::default();
+                config.store_at(path).unwrap();
+
+                config.into_loaded().unwrap()
+            })
+    }
+
+    fn load(&mut self) -> Result<(), KeyMaterialLoadingFailure> {
+        self.key.load()
+    }
+
+    fn into_loaded(mut self) -> Result<Self, KeyMaterialLoadingFailure> {
+        self.load()?;
+        Ok(self)
+    }
+
+    fn parse(s: &str) -> Self {
+        serde_json::from_str(s).unwrap()
+    }
+
+    pub fn store_at<P: AsRef<Path>>(&self, path: P) -> std::io::Result<()> {
+        let string = serde_json::to_string_pretty(self).unwrap();
+        fs::write(path, string)
     }
 
     pub fn secio_key_pair(&self) -> Keypair {
-        // FIXME: the keypair should be extract at load time and only cloned here
-        // there could also some (de)serialization support in libp2p like there is for rsa and
-        // secp256k1?
-        let mut cloned = self.private_key.clone();
-        let sk = libp2p::identity::ed25519::SecretKey::from_bytes(&mut cloned)
-            .expect("Failed to extract ed25519::SecretKey");
-
-        let kp = libp2p::identity::ed25519::Keypair::from(sk);
-
-        Keypair::Ed25519(kp)
+        self.key.clone_keypair()
     }
 
     pub fn peer_id(&self) -> PeerId {
-        self.secio_key_pair().public().into_peer_id()
+        self.key.public().into_peer_id()
     }
 
     pub fn bootstrap(&self) -> Vec<(Multiaddr, PeerId)> {
@@ -69,13 +169,48 @@ impl ConfigFile {
 
 impl Default for ConfigFile {
     fn default() -> Self {
+        // the ed25519 has no chance of working with go-ipfs as of now because of
+        // https://github.com/libp2p/specs/issues/138 and
+        // https://github.com/libp2p/go-libp2p-core/blob/dc718fa4dab1866476fd9f379718fdd619455a4f/peer/peer.go#L23-L34
+        //
+        // and on the other hand:
+        // https://github.com/libp2p/rust-libp2p/blob/eb7b7bd919b93e6acf00847c19d1a76c09016120/core/src/peer_id.rs#L62-L74
         let private_key: [u8; 32] = EntropyRng::new().gen();
+
         let bootstrap = BOOTSTRAP_NODES.iter().map(|node| {
             node.parse().unwrap()
         }).collect();
         ConfigFile {
-            private_key,
+            key: KeyMaterial::Ed25519 { private_key, keypair: None }.into_loaded().unwrap(),
             bootstrap,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::ConfigFile;
+
+    #[test]
+    fn supports_older_v1_and_ed25519_v2() {
+        let input = r#"{"private_key":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"bootstrap":[]}"#;
+
+        let actual = ConfigFile::parse(input);
+
+        let roundtrip = serde_json::to_string(&actual).unwrap();
+
+        assert_eq!(input, roundtrip);
+    }
+
+    #[test]
+    fn supports_v2() {
+        let input = r#"{"rsa_pkcs8_filename":"foobar.pk8","bootstrap":[]}"#;
+
+        let actual = ConfigFile::parse(input);
+
+        let roundtrip = serde_json::to_string(&actual).unwrap();
+
+        assert_eq!(input, roundtrip);
     }
 }

--- a/src/ipns/dns.rs
+++ b/src/ipns/dns.rs
@@ -82,6 +82,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_resolve2() {
         async_test(async move {
             let res = resolve("website.ipfs.io").unwrap().await.unwrap().to_string();


### PR DESCRIPTION
With an RSA key and `go-ipfs` 0.4.22 I was able to provide the `"block-want\n"` from go-ipfs and connect go-ipfs with rust-ipfs as a bootstrap peer. The big upgrade left the output a bit bad: it no longer prints the listening address and this needs to be fetched at `IpfsFuture` which I did not add here.

`ring` does not have RSA key generation yet but if you want to test this with an rsa key you can follow [the instructions in libp2p docs](https://docs.rs/libp2p-core/0.13.1/src/libp2p_core/identity.rs.html#38) and create a config.json like (from the test case), use it with `IPFS_TEST_CONFIG` environment variable.

```json
{"rsa_pkcs8_filename":"foobar.pk8","bootstrap":[]}
```

This includes an update to the deps to have the `aes-ctr` fix I am working on `RustCrypto/stream-ciphers`. The code works but doesn't likely fit in the stream-ciphers so that PR is going to live for a while until mentorship arrives.

`src/config.rs` edits are quite horrible as the `libp2p::identity::Keypair` is not `Clone`. On a pro side it is backwards compatible with the old configuration file :)