### PR TITLE
Migrating to stable: Replaced NoneError with TryError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly-2019-11-21
+  - stable
 cache: cargo
 script:
   - cargo test

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2019-11-21
+stable

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,1 +1,3 @@
 pub use failure::Error;
+
+pub struct TryError;

--- a/src/ipld/formats/pb/mod.rs
+++ b/src/ipld/formats/pb/mod.rs
@@ -1,5 +1,5 @@
 use crate::block::Cid;
-use crate::error::Error;
+use crate::error::{Error, TryError};
 use crate::ipld::Ipld;
 use crate::path::PathRoot;
 use cid::Prefix;
@@ -96,41 +96,56 @@ impl Into<Ipld> for PbLink {
 }
 
 impl TryFrom<Ipld> for PbNode {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_from(ipld: Ipld) -> Result<PbNode, Self::Error> {
         match ipld {
             Ipld::Object(mut map) => {
-                let links: Vec<Ipld> = map.remove("Links")?.try_into()?;
+                let links: Vec<Ipld> = match map.remove("Links") {
+                    Some(links) => links.try_into()?,
+                    None => return Err(TryError)
+                };
                 let links: Vec<PbLink> = links.into_iter()
                     .map(|link| link.try_into()).collect::<Result<_, Self::Error>>()?;
-                let data: Vec<u8> = map.remove("Data")?.try_into()?;
+                let data: Vec<u8> = match map.remove("Data") {
+                    Some(data) => data.try_into()?,
+                    None => return Err(TryError)
+                };
                 Ok(PbNode {
                     links,
                     data,
                 })
             }
-            _ => None?
+            _ => Err(TryError)
         }
     }
 }
 
 impl TryFrom<Ipld> for PbLink {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_from(ipld: Ipld) -> Result<PbLink, Self::Error> {
         match ipld {
             Ipld::Object(mut map) => {
-                let cid: PathRoot = map.remove("Hash")?.try_into()?;
-                let name: String = map.remove("Name")?.try_into()?;
-                let size: u64 = map.remove("Tsize")?.try_into()?;
+                let cid: PathRoot = match map.remove("Hash") {
+                    Some(cid) => cid.try_into()?,
+                    None => return Err(TryError)
+                };
+                let name: String = match map.remove("Name") {
+                    Some(name) => name.try_into()?,
+                    None => return Err(TryError)
+                };
+                let size: u64 = match map.remove("Tsize") {
+                    Some(size) => size.try_into()?,
+                    None => return Err(TryError)
+                };
                 Ok(PbLink {
                     cid,
                     name,
                     size,
                 })
             }
-            _ => None?
+            _ => Err(TryError)
         }
     }
 }

--- a/src/ipld/formats/pb/mod.rs
+++ b/src/ipld/formats/pb/mod.rs
@@ -101,16 +101,10 @@ impl TryFrom<Ipld> for PbNode {
     fn try_from(ipld: Ipld) -> Result<PbNode, Self::Error> {
         match ipld {
             Ipld::Object(mut map) => {
-                let links: Vec<Ipld> = match map.remove("Links") {
-                    Some(links) => links.try_into()?,
-                    None => return Err(TryError)
-                };
+                let links: Vec<Ipld> = map.remove("Links").ok_or(TryError)?.try_into()?;
                 let links: Vec<PbLink> = links.into_iter()
                     .map(|link| link.try_into()).collect::<Result<_, Self::Error>>()?;
-                let data: Vec<u8> = match map.remove("Data") {
-                    Some(data) => data.try_into()?,
-                    None => return Err(TryError)
-                };
+                let data: Vec<u8> = map.remove("Data").ok_or(TryError)?.try_into()?;
                 Ok(PbNode {
                     links,
                     data,
@@ -127,18 +121,9 @@ impl TryFrom<Ipld> for PbLink {
     fn try_from(ipld: Ipld) -> Result<PbLink, Self::Error> {
         match ipld {
             Ipld::Object(mut map) => {
-                let cid: PathRoot = match map.remove("Hash") {
-                    Some(cid) => cid.try_into()?,
-                    None => return Err(TryError)
-                };
-                let name: String = match map.remove("Name") {
-                    Some(name) => name.try_into()?,
-                    None => return Err(TryError)
-                };
-                let size: u64 = match map.remove("Tsize") {
-                    Some(size) => size.try_into()?,
-                    None => return Err(TryError)
-                };
+                let cid: PathRoot = map.remove("Hash").ok_or(TryError)?.try_into()?;
+                let name: String = map.remove("Name").ok_or(TryError)?.try_into()?;
+                let size: u64 = map.remove("Tsize").ok_or(TryError)?.try_into()?;
                 Ok(PbLink {
                     cid,
                     name,

--- a/src/ipld/ipld.rs
+++ b/src/ipld/ipld.rs
@@ -1,5 +1,5 @@
 use crate::block::{Block, Cid};
-use crate::error::Error;
+use crate::error::{Error, TryError};
 use crate::ipld::{formats, IpldError};
 use crate::path::{IpfsPath, PathRoot};
 use cid::Codec;
@@ -165,111 +165,111 @@ impl From<IpfsPath> for Ipld {
 }
 
 impl TryInto<u64> for Ipld {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_into(self) -> Result<u64, Self::Error> {
         match self {
             Ipld::U64(u) => Ok(u),
-            _ => Err(None?)
+            _ => Err(TryError)
         }
     }
 }
 
 impl TryInto<i64> for Ipld {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_into(self) -> Result<i64, Self::Error> {
         match self {
             Ipld::I64(i) => Ok(i),
-            _ => Err(None?)
+            _ => Err(TryError)
         }
     }
 }
 
 impl TryInto<Vec<u8>> for Ipld {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_into(self) -> Result<Vec<u8>, Self::Error> {
         match self {
             Ipld::Bytes(bytes) => Ok(bytes),
-            _ => Err(None?)
+            _ => Err(TryError)
         }
     }
 }
 
 impl TryInto<String> for Ipld {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_into(self) -> Result<String, Self::Error> {
         match self {
             Ipld::String(string) => Ok(string),
-            _ => Err(None?)
+            _ => Err(TryError)
         }
     }
 }
 
 impl TryInto<Vec<Ipld>> for Ipld {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_into(self) -> Result<Vec<Ipld>, Self::Error> {
         match self {
             Ipld::Array(vec) => Ok(vec),
-            _ => Err(None?)
+            _ => Err(TryError)
         }
     }
 }
 
 impl TryInto<HashMap<String, Ipld>> for Ipld {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_into(self) -> Result<HashMap<String, Ipld>, Self::Error> {
         match self {
             Ipld::Object(map) => Ok(map),
-            _ => Err(None?)
+            _ => Err(TryError)
         }
     }
 }
 
 impl TryInto<f64> for Ipld {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_into(self) -> Result<f64, Self::Error> {
         match self {
             Ipld::F64(f) => Ok(f),
-            _ => Err(None?)
+            _ => Err(TryError)
         }
     }
 }
 
 impl TryInto<bool> for Ipld {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_into(self) -> Result<bool, Self::Error> {
         match self {
             Ipld::Bool(b) => Ok(b),
-            _ => Err(None?)
+            _ => Err(TryError)
         }
     }
 }
 
 impl TryInto<PathRoot> for Ipld {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_into(self) -> Result<PathRoot, Self::Error> {
         match self {
             Ipld::Link(root) => Ok(root),
-            _ => Err(None?)
+            _ => Err(TryError)
         }
     }
 }
 
 impl TryInto<Cid> for Ipld {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_into(self) -> Result<Cid, Self::Error> {
         match self {
             Ipld::Link(root) => root.try_into(),
-            _ => Err(None?)
+            _ => Err(TryError)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 //! IPFS node implementation
 //#![deny(missing_docs)]
-#![feature(try_trait)]
 
 #[macro_use] extern crate failure;
 #[macro_use] extern crate log;

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -1,5 +1,5 @@
 use crate::block::Cid;
-use crate::error::Error;
+use crate::error::{Error, TryError};
 use libp2p::PeerId;
 use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
@@ -203,23 +203,23 @@ impl From<PeerId> for PathRoot {
 }
 
 impl TryInto<Cid> for PathRoot {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_into(self) -> Result<Cid, Self::Error> {
         match self {
             PathRoot::Ipld(cid) => Ok(cid),
-            _ => None?,
+            _ => Err(TryError),
         }
     }
 }
 
 impl TryInto<PeerId> for PathRoot {
-    type Error = std::option::NoneError;
+    type Error = TryError;
 
     fn try_into(self) -> Result<PeerId, Self::Error> {
         match self {
             PathRoot::Ipns(peer_id) => Ok(peer_id),
-            _ => None?,
+            _ => Err(TryError),
         }
     }
 }


### PR DESCRIPTION
Sorry for removing my original comment to the relevant issue #36 where I was asking about using `void::Void` to remove the `try_trait` feature.

In this PR I've added the unit struct, `TryError`, to `src/error.rs` to replace all cases of `NoneError`.

All tests appear to succeed when executing `cargo test` from stable, but I was unsure how to test the example files.